### PR TITLE
Hotfix desafio

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -120,7 +120,7 @@ services:
       - -c
       - |
         mkdir -p /sources/logs /sources/dags /sources/plugins
-        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
+        chown -R "$${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
         exec /entrypoint airflow version
     environment:
       <<: *airflow-common-env

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,7 +57,7 @@ services:
     ports:
       - 8080:8080
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:xxxx/health"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ x-airflow-common:
     - ./dag:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
-  user: "5000"
+  user: "50000"
   depends_on:
     &airflow-common-depends-on
     redis:

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ x-airflow-common:
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
     TZ: 'America/Sao_Paulo'
   volumes:
-    - ./dag:/opt/airflow/dags
+    - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
   user: "50000"

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ x-airflow-common:
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
+    TZ: 'America/Sao_Paulo'
   volumes:
     - ./dag:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
@@ -28,7 +29,7 @@ services:
     ports:
       - 5432:5432
     environment:
-      POSTGRES_USER: admin
+      POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
       POSTGRES_DB: airflow
     volumes:

--- a/dags/smooth.py
+++ b/dags/smooth.py
@@ -9,7 +9,7 @@ from datetime import datetime
     catchup=False,
     tags=["smooth"],
 )
-def smooth()
+def smooth():
     video = SmoothOperator(
         task_id="youtube_video"
     )


### PR DESCRIPTION
## **PROBLEMA**:

Em geral, não é possível fazer uso da stack do Airflow conforme a mesma se encontra declarada no arquivo [compose.yaml](./compose.yaml).

Antes de abordar cada ponto, é interessante mencionar que ao executar o comando `docker compose up -d` no diretório do projeto, é observado que o serviço `airflow-init` apresenta a mensagem e *status* como:
``` text
# message:
service "airflow-init" didn't complete successfully: exit 1

# container status:
Exited (1) About a minute ago
```
Consecutivamente, os serviços que possuem dependência ao `airflow-init`, não chegam a iniciar.
Abaixo segue o *troubleshooting* realizado.

---

## **Investigação do problema**:

### 1. Mensagem de *warning* para variável `AIRFLOW_UID`:
Antes de analisar diretamente o log de qualquer serviço, osbervei que qualquer subcomando do `docker compose` apresenta o seguinte *warning*:
```text
WARN[0000] The "AIRFLOW_UID" variable is not set. Defaulting to a blank string.
```
Esta mensagem é do próprio "interpretador" do *docker compose*, e indica que uma variável utilizada não possuí seu valor definido. Encontramos esta variável na linha 124, do arquivo [compose.yaml](./compose.yaml), dentro do diretório raiz do projeto.

#### Solução:
Para resolver este caso, podemos adotar uma de três estratégias:
1. Técnica de interpolação, na declaração do arquivo `compose.yaml`, para adicionar um valor *default* à variável
```shell
chown -R "${AIRFLOW_UID:-5000}:0" /sources/{logs,dags,plugins}
```

2. Utilizar o output do comando `id`, dentro do container, para coletar o *uid* do usuário `airflow`
```shell
chown -R "$(uid -u airflow):0" /sources/{logs,dags,plugins}
```

3. Ajustar a declaração da variável para que seja utilizada a variável de ambiente, que se encontra dentro do container
```shell
chown -R "$${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
```

Visto que a variável `AIRFLOW_UID` já possuí seu valor declarado, dentro do container, a **opção 3** torna-se a mais indicada.

---

### 2. Erro de conexão ao serviço do PostgreSQL:

Posteriormente, para analisar os logs do serviço `airflow-init`, foi executado o comando:
```shell
docker compose logs airflow-init
```
Em análise ao resultado, nota-se que não é possível conectar no serviço `postgres`, devido a uma falha de autenticação.
```shell
# comando executado para coletar os logs do serviço airflow-init:
docker compose logs airflow-init

# resultado em parciais:
WARNING - Failed to log action (psycopg2.OperationalError) connection to server at "postgres" (172.19.0.3), port 5432 failed: FATAL:  password authentication failed for user "airflow"
...
psycopg2.OperationalError: connection to server at "postgres" (172.19.0.3), port 5432 failed: FATAL:  password authentication failed for user "airflow"
...
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "postgres" (172.19.0.3), port 5432 failed: FATAL:  password authentication failed for user "airflow"
``` 

Antes de qualquer outra alteração, foi feito a análise do *status* do serviço `postgres`, e uma conexão via comando `psql`, para validar o funcionamento da *database instance*. Foi possível mostrar a versão da *database engine* instalada, sem qualquer problema:
```shell
# análise do status do serviço
docker compose ps -a postgres

# resultado:
NAME                          IMAGE         COMMAND                  SERVICE    CREATED          STATUS                    PORTS
pismo-dre-3-test-postgres-1   postgres:13   "docker-entrypoint.s…"   postgres   28 minutes ago   Up 28 minutes (healthy)   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp

# executado comando que mostra a versão do postgres, através do container:
docker compose exec postgres psql -h localhost -p 5432 -U admin postgres -c 'select version()'

# resultado:
                                                        version                                                        
-----------------------------------------------------------------------------------------------------------------------
 PostgreSQL 13.16 (Debian 13.16-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
(1 row)
```
#### Solução:
Uma vez que não foi constatado nada de incorreto no serviço do `postgres`, e visto que os logs do serviço `airflow-init` indicam falha na autenticação, foi optado por ajustar a declaração do usuário de conexão ao banco de dados, na linha 32.

É importante remover o volume do *docker* que foi criado ao iniciar os serviço, antes de realizar uma nova tentativa, pois assim todo o processo de *setup* do serviço `postgres` será refeito.

---

### 3. Containers dos principais serviços não chegam no status `healthy`:

Após executar mais uma vez o comando `docker compose ps -a`, para analisar os containers, nota-se que os serviços `airflow-scheduler`, `airflow-triggerer`, `airflow-webserver` e `airflow-worker` não chegam ao status de `healthy`.

```shell
docker compose ps -a

# resultado:
NAME                                   IMAGE                  COMMAND                  SERVICE             CREATED         STATUS                             PORTS
pismo-dre-3-test-airflow-init-1        apache/airflow:2.5.1   "/bin/bash -c 'mkdir…"   airflow-init        9 minutes ago   Exited (0) 9 minutes ago           
pismo-dre-3-test-airflow-scheduler-1   apache/airflow:2.5.1   "/usr/bin/dumb-init …"   airflow-scheduler   9 minutes ago   Up 16 seconds (health: starting)   8080/tcp
pismo-dre-3-test-airflow-triggerer-1   apache/airflow:2.5.1   "/usr/bin/dumb-init …"   airflow-triggerer   9 minutes ago   Up 17 seconds (health: starting)   8080/tcp
pismo-dre-3-test-airflow-webserver-1   apache/airflow:2.5.1   "/usr/bin/dumb-init …"   airflow-webserver   9 minutes ago   Up 17 seconds (health: starting)   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp
pismo-dre-3-test-airflow-worker-1      apache/airflow:2.5.1   "/usr/bin/dumb-init …"   airflow-worker      9 minutes ago   Up 17 seconds (health: starting)   8080/tcp
pismo-dre-3-test-postgres-1            postgres:13            "docker-entrypoint.s…"   postgres            9 minutes ago   Up 9 minutes (healthy)             0.0.0.0:5432->5432/tcp, :::5432->5432/tcp
pismo-dre-3-test-redis-1               redis:latest           "docker-entrypoint.s…"   redis               9 minutes ago   Up 9 minutes (healthy)             6379/tcp
```

Analisando os logs do serviço `airflow-scheduler` por exemplo, encontramos repetidas vezes informações referentes a um diretório não existente, e a falta de permissão para criá-lo:
```shell
airflow-scheduler-1  | Traceback (most recent call last):
airflow-scheduler-1  |   File "/usr/local/lib/python3.7/pathlib.py", line 1273, in mkdir
airflow-scheduler-1  |     self._accessor.mkdir(self, mode)
airflow-scheduler-1  | FileNotFoundError: [Errno 2] No such file or directory: '/opt/airflow/logs/scheduler/2024-10-16'
airflow-scheduler-1  | 
airflow-scheduler-1  | During handling of the above exception, another exception occurred:
airflow-scheduler-1  | 
airflow-scheduler-1  | Traceback (most recent call last):
airflow-scheduler-1  |   File "/usr/local/lib/python3.7/logging/config.py", line 563, in configure
airflow-scheduler-1  |     handler = self.configure_handler(handlers[name])
airflow-scheduler-1  |   File "/usr/local/lib/python3.7/logging/config.py", line 736, in configure_handler
airflow-scheduler-1  |     result = factory(**kwargs)
airflow-scheduler-1  |   File "/home/airflow/.local/lib/python3.7/site-packages/airflow/utils/log/file_processor_handler.py", line 49, in __init__
airflow-scheduler-1  |     Path(self._get_log_directory()).mkdir(parents=True, exist_ok=True)
airflow-scheduler-1  |   File "/usr/local/lib/python3.7/pathlib.py", line 1277, in mkdir
airflow-scheduler-1  |     self.parent.mkdir(parents=True, exist_ok=True)
airflow-scheduler-1  |   File "/usr/local/lib/python3.7/pathlib.py", line 1273, in mkdir
airflow-scheduler-1  |     self._accessor.mkdir(self, mode)
airflow-scheduler-1  | PermissionError: [Errno 13] Permission denied: '/opt/airflow/logs/scheduler'
```

Esta situação e logs se repetem com os demais serviços que apresentam falha.

Observando a construção do serviço `airflow-scheduler` no arquivo `compose.yaml`, notamos que o diretório `./logs` do host local é montado para o diretório do container `/opt/airflow/logs`.

O diretório `./logs` do host local está com o seu usuário *owner* para o *UID* 50000 (cinquenta mil), esta informação coincide com o valor da variável de ambiente `AIRFLOW_UID`, que encontramos dentro dos containers:
```shell
docker compose exec airflow-scheduler /bin/bash -c 'echo $AIRFLOW_UID'

# resultado:
50000
```

Entretanto, ainda na construção dos serviços, dentro do arquivo `compose.yaml`, também podemos notar que a linha 18 coloca como usuário de execução para os containers o *UID* para **5000** (cinco mil), o que gera um "conflito" de acesso/permissões para execução de todos os serviços que estão apresentando falha, neste momento.

#### Solução:

Para corrigir esse conflito, foi ajustado na linha 18, do arquivo `compose.yaml` o **UID** do usuário de execução dos containers, para o código **50000** (cinquenta mil).

Neste caso, após interromper e antes de iniciar novamente os serviços, também é importante remover o volume do *docker* para testar por completo o *setup* de todo o projeto.

---

### 4. Serviço `airflow-webserver` com status `unhealthy`:

Observa-se que apenas o serviço `airflow-webserver` apresenta o status de `unhealthy`.

Foi executado o comando `docker compose logs airflow-webserver`, mas nenhum log de erro foi localizado.

Também nota-se que a *interface web* do serviço, exposta na porta 8080 está disponível para acesso, e aceita as credenciais de acesso normalmente.

Analisando a construção do serviço `airflow-webserver` no arquivo `compose.yaml`, nota-se que a instrução de teste do bloco `check` possuí um erro na inforamção de porta do *endpoint* usando para *healthcheck*. Na linha 60, onde deveríamos encontrar o valor de **8080**, encontramos **xxxx**, logo não é possível para o *docker* concluir a verificação, e o status do *container* fica como `unhealthy` mesmo sem nenhum log de erro, ou falha na execução da *interface web*.

#### Solução:

Para ajustar o caso, foi alterado o valor de **xxxx** para **8080**, na linha 60.

---

### 5. Não é possível encontrar a DAG de nome *smooth*, dentro da *interface web* do Airflow:

Uma vez sendo possível acessar a *interface web* do Airflow pelo navegador, constata-se que nenhum DAG é apresentada, mesmo que exista o código [smooth.py](./dags/smooth.py) para criá-la.

Para fins de análise, foi listado o conteúdo do diretório `/opt/airflow/dags`, conforme instrução declarada na linha 15 do arquivo [compose.yaml](./compose.yaml). Entretanto, nenhum conteúdo/arquivo foi localizado:
```shell
$ docker compose exec airflow-webserver /bin/bash -c 'ls -lht /opt/airflow/dags' 

# resultado
total 0
```

Ainda em análise na mesma linha 15, nota-se que o diretório do host local declarado como `./dag` é inexistente, logo identifica-se um possível erro de declaração do volume, onde o correto seria `./dags`.

Após reiniciar os serviços, para novo teste, nota-se que agora é possível encontrar o arquivo `/opt/airflow/dags/smooth.py`:
```shell
$ docker compose exec airflow-webserver /bin/bash -c 'ls -lht /opt/airflow/dags' 

# resultado
total 8.0K
-rw-r--r-- 1 airflow root  313 Oct 16 00:38 smooth.py
drwxrwxr-x 2 airflow root 4.0K Oct 16 00:34 __pycache__
```

Porém, ao entrar na *interface web* do Airflow, nota-se uma mensagem de erro, no topo da página:
```text
DAG Import Errors (1)
    Broken DAG: [/opt/airflow/dags/smooth.py] Traceback (most recent call last):
        File "<frozen importlib._bootstrap_external>", line 791, in source_to_code
        File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
        File "/opt/airflow/dags/smooth.py", line 12
            def smooth()
                    ^
    SyntaxError: invalid syntax
```

Analisando o arquivo [smooth.py](./dags/smooth.py) nota-se que na linha 12 há um erro ao declarar a função `smooth`, não foi utilizado ao final da mesma o símbolo de dois-pontos `:`.

#### Solução

Na linha 15, do arquivo [compose.yaml](./compose.yaml), foi ajustado a declaração do volume, apontando para o diretório local `./dags`, ao invés de `./dag`.

No arquivo `./dags/smooth.py`, na linha 12, foi adicionado o símbolo de dois-ponto, ao final da declaração da função.

Para realizar novo teste, basta reiniciar todos os serviços, e entrar novamente na *interface web* do Airflow, para conferir se a DAG de nome smooth é apresentada na tela inicial.

---